### PR TITLE
Use alias method chain technique to replace "render"

### DIFF
--- a/lib/active_scaffold/extensions/action_controller_rendering.rb
+++ b/lib/active_scaffold/extensions/action_controller_rendering.rb
@@ -1,17 +1,32 @@
 # wrap the action rendering for ActiveScaffold controllers
 module ActiveScaffold
   module ActionController #:nodoc:
-    def render(*args, &block)
+
+    def self.prepended(base)
+      # Protect from trying to augment modules that appear
+      # as the result of adding other gems.
+      return if base != ::ActionController::Base
+
+      base.class_eval do
+        alias_method :render_without_active_scaffold, :render
+
+        def render(*args, &block)
+          render_with_active_scaffold(*args, &block)
+        end
+      end
+    end
+
+    def render_with_active_scaffold(*args, &block)
       if self.class.uses_active_scaffold? && params[:adapter] && @rendering_adapter.nil? && request.xhr?
         @rendering_adapter = true # recursion control
         # if we need an adapter, then we render the actual stuff to a string and insert it into the adapter template
         opts = args.blank? ? {} : args.first
-        render :partial => params[:adapter][1..-1],
+        render_without_active_scaffold  :partial => params[:adapter][1..-1],
                :locals => {:payload => render_to_string(opts.merge(:layout => false), &block).html_safe},
                :use_full_path => true, :layout => false, :content_type => :html
         @rendering_adapter = nil # recursion control
       else
-        super(*args, &block)
+        render_without_active_scaffold(*args, &block)
       end
     end
   end


### PR DESCRIPTION
When used with other gems that also replace ActionController::Base#render, the previous code may cause infinite loop that eventually generates a SystemStackError (stack level too deep).

For example, when I used active_scaffold with wicked_pdf on Rails 5.1.2 with ruby 2.4.0 (x86_64-linux), the error was logged as follows:

```
 SystemStackError (stack level too deep):
 
 (path_to)/active_scaffold-e897d49ce1e0/lib/active_scaffold/core.rb:150:in `active_scaffold_config'
 (path_to)/active_scaffold-e897d49ce1e0/lib/active_scaffold/core.rb:151:in `active_scaffold_config'
 (path_to)/active_scaffold-e897d49ce1e0/lib/active_scaffold/core.rb:185:in `uses_active_scaffold?'
 (path_to)/active_scaffold-e897d49ce1e0/lib/active_scaffold/extensions/action_controller_rendering.rb:5:in `render'
 wicked_pdf (1.1.0) lib/wicked_pdf/pdf_helper.rb:42:in `render_with_wicked_pdf'
 wicked_pdf (1.1.0) lib/wicked_pdf/pdf_helper.rb:27:in `render'
 (path_to)/active_scaffold-e897d49ce1e0/lib/active_scaffold/extensions/action_controller_rendering.rb:14:in `render'
 wicked_pdf (1.1.0) lib/wicked_pdf/pdf_helper.rb:42:in `render_with_wicked_pdf'
 wicked_pdf (1.1.0) lib/wicked_pdf/pdf_helper.rb:27:in `render'
 (path_to)/active_scaffold-e897d49ce1e0/lib/active_scaffold/extensions/action_controller_rendering.rb:14:in `render'
 wicked_pdf (1.1.0) lib/wicked_pdf/pdf_helper.rb:42:in `render_with_wicked_pdf'
 wicked_pdf (1.1.0) lib/wicked_pdf/pdf_helper.rb:27:in `render'
 ...
```

To avoid this infinite loop, in this patch, the standard "alias method chain" technique was used to replace the ActionController::Base#render.
